### PR TITLE
Add security scan to the 'Release' CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Init
         uses: actions/setup-go@v3
         with:
-          go-version: 1.15
+          go-version: 1.16
         id: go
 
       - name: Checkout
@@ -31,6 +31,12 @@ jobs:
 
       - name: Test
         run: go test -v $(go list ./... | grep -v vendor | grep -v mocks) -race -coverprofile=coverage.txt -covermode=atomic
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2
 
       - name: Build AMD64
         run: |


### PR DESCRIPTION
This PR contains code in order to add a security scan to the 'Release' CI.